### PR TITLE
Responsive Values

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -5,14 +5,15 @@ import Title from "./Title";
 
 const About = () => {
   return (
-    <div className="flex flex-col lg:flex-row mx-0 sm:mx-10 py-12 sm:px-10 gap-10 justify-center font-nunito items-center lg:items-start">
-      <Image
-        src={GroupPhoto}
-        alt="AIS Group Photo"
-        className="w-10/12 sm:w-5/12 shadow-[-17px_-17px_0px_0px_#dce6f9] rounded-2xl mr-[17px] object-cover h-auto"
-      />
-
-      <div className="flex flex-col justify-center space-y-6 w-full lg:w-2/3 py-5 text-left">
+    <div className="flex flex-col lg:flex-row mx-0 sm:mx-10 py-12 sm:px-10 gap-5 md:gap-10 justify-center font-nunito items-center lg:items-start">
+      <div className="w-11/12 lg:w-5/12 flex ml-4 sm:ml-0">
+        <Image
+          src={GroupPhoto}
+          alt="AIS Group Photo"
+          className="shadow-[-17px_-17px_0px_0px_#dce6f9] rounded-2xl mr-[17px] object-cover h-auto "
+        />
+      </div>
+      <div className="flex flex-col justify-center space-y-6 w-11/12 lg:w-2/3 py-5 text-left">
         <div className="flex justify-center lg:justify-start">
           <Title title={"ABOUT US"} />
         </div>

--- a/src/components/Join.jsx
+++ b/src/components/Join.jsx
@@ -10,7 +10,7 @@ const Join = () => {
         <div className="flex justify-center lg:justify-end text-center lg:text-right">
           <Title title={"WHY JOIN"} />
         </div>
-        <div className="text-center lg:text-right text-base md:text-lg my-4">
+        <div className="text-left lg:text-right text-base md:text-lg my-4">
           suspendisse ultrices gravida dictum fusce ut placerat orci nulla
           pellentesque dignissim enim sit amet venenatis urna cursus eget nunc
           scelerisque viverra mauris in aliquam sem fringilla ut morbi tincidunt

--- a/src/components/Value.jsx
+++ b/src/components/Value.jsx
@@ -4,13 +4,13 @@ import Image from "next/image";
 const Value = ({ title, text, image, color }) => {
   return (
     <div
-      className={`flex flex-col items-center w-80 h-88  mx-10 p-6 gap-4 rounded-2xl text-white font-nunito ${color}`}
+      className={`flex flex-col items-center w-80 h-88 mx-10 md:mx-2 xl:mx-10 p-6 gap-4 rounded-2xl text-white font-nunito ${color}`}
     >
       <Image src={image} alt="icon" className="mt-2" />
-      <div className="font-extrabold text-4xl text-center tracking-wide">
+      <div className="font-extrabold  text-3xl xl:text-4xl text-center tracking-wide">
         {title}
       </div>
-      <div className="cont-semibold text-2xl text-center w-full mb-4">
+      <div className="cont-semibold text-xl xl:text-2xl text-center w-full mb-4">
         {text}
       </div>
     </div>

--- a/src/components/Values.jsx
+++ b/src/components/Values.jsx
@@ -7,7 +7,7 @@ const Values = () => {
   return (
     <div className="flex flex-col items-center w-full gap-10 font-nunito">
       <Title title={"OUR VALUES"} />
-      <div className="flex justify-center gap-10 w-full">
+      <div className="flex flex-col md:flex-row lg:flex-row justify-center gap-5 xl:gap-10 w-full">
         {VALUES.map((item, index) => (
           <Value
             title={item.title}


### PR DESCRIPTION
Made the values responsive for mobile devices. Used iPhone Pro as reference here:
![responsiveValuesiPhonePro1](https://github.com/user-attachments/assets/d6d6cfc6-331b-49de-b70f-5266e46dffab)
![responsiveValuesiPhonePro2](https://github.com/user-attachments/assets/f6c86c98-39ea-4dc1-947b-9812860aa5e0)

Then used iPad Pro as reference here: 
![responsiveValuesiPadPro](https://github.com/user-attachments/assets/22b02c63-4411-416f-8536-e91254905366)

also made text slightly smaller